### PR TITLE
a float that is forcible to int without loss of information is valid.

### DIFF
--- a/src/Constraint/Type/IntegerNumberValidator.php
+++ b/src/Constraint/Type/IntegerNumberValidator.php
@@ -22,13 +22,8 @@ class IntegerNumberValidator extends ConstraintValidator
             return;
         }
 
-        // if value is float, force to string. This will cast 5.0 => '5', and 5.5 => '5.5'
-        if (is_float($value)) {
-            $value = (string)$value;
-        }
-
-        // value should be either int or string
-        if (is_string($value) === false) {
+        // value should be either float or string
+        if (is_string($value) === false && is_float($value) === false) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode($constraint::INVALID_VALUE_TYPE)
@@ -37,7 +32,7 @@ class IntegerNumberValidator extends ConstraintValidator
         }
 
         // value can't be cast to int
-        if (((string)(int)$value) !== $value) {
+        if (((string)(int)$value) !== (string)$value) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode($constraint::INVALID_NUMBER_ERROR)

--- a/src/Constraint/Type/IntegerNumberValidator.php
+++ b/src/Constraint/Type/IntegerNumberValidator.php
@@ -22,6 +22,11 @@ class IntegerNumberValidator extends ConstraintValidator
             return;
         }
 
+        // if value is float, force to string. This will cast 5.0 => '5', and 5.5 => '5.5'
+        if (is_float($value)) {
+            $value = (string)$value;
+        }
+
         // value should be either int or string
         if (is_string($value) === false) {
             $this->context->buildViolation($constraint->message)

--- a/tests/Unit/Constraint/Type/IntegerNumberValidatorTest.php
+++ b/tests/Unit/Constraint/Type/IntegerNumberValidatorTest.php
@@ -13,7 +13,6 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Validation;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @coversDefaultClass \DigitalRevolution\SymfonyValidationShorthand\Constraint\Type\IntegerNumberValidator
@@ -72,11 +71,13 @@ class IntegerNumberValidatorTest extends TestCase
             '-1'        => ['-1', 0],
             'int 1'     => [1, 0],
             'int 0'     => [0, 0],
+            'float 5.0' => [5.0, 0],
             // failures
             ''          => ['', 1],
             'a'         => ['a', 1],
             '0 prefix'  => ['01', 1],
             'true'      => ['true', 1],
+            'float 5.5' => [5.5, 1],
             'bool true' => [true, 1],
             '-'         => ['-', 1],
             'max int'   => [PHP_INT_MAX . '2', 1]


### PR DESCRIPTION
`|int` validation rule should also allow floats without decimal precision. 

**Valid:**
5.0, -5.0, 0.0

**Invalid:**
5.5, -5.5, 0.1