### PR TITLE
Add support to ignore Constraint[] in ConstraintFactory

### DIFF
--- a/src/ConstraintFactory.php
+++ b/src/ConstraintFactory.php
@@ -30,16 +30,15 @@ class ConstraintFactory
     }
 
     /**
-     * @param Constraint|array<string, string|Constraint|array<string|Constraint>> $ruleDefinitions
-     * @param bool                                                                 $allowExtraFields Allow for extra, unvalidated, fields to be sent
-     *                                                                                               to the constraint collection
+     * @param Constraint|array<string|Constraint|array<string|Constraint>> $ruleDefinitions
+     * @param bool                                                         $allowExtraFields Allow for extra, unvalidated, fields to be
      *
      * @return Constraint|Constraint[]
      * @throws InvalidRuleException
      */
     public function fromRuleDefinitions($ruleDefinitions, bool $allowExtraFields = false)
     {
-        if ($ruleDefinitions instanceof Constraint) {
+        if ($ruleDefinitions instanceof Constraint || self::isConstraintList($ruleDefinitions)) {
             return $ruleDefinitions;
         }
 
@@ -58,5 +57,23 @@ class ConstraintFactory
 
         // transform ConstraintMap to ConstraintCollection
         return $this->collectionBuilder->setAllowExtraFields($allowExtraFields)->build($constraintMap);
+    }
+
+    /**
+     * Check if `definition` is of type `array<int, Constraint>`
+     *
+     * @param array<string|Constraint|array<string|Constraint>> $ruleDefinitions
+     *
+     * @phpstan-assert-if-true Constraint[]                     $ruleDefinitions
+     */
+    private static function isConstraintList(array $ruleDefinitions): bool
+    {
+        foreach ($ruleDefinitions as $key => $definition) {
+            if (is_int($key) === false || $definition instanceof Constraint === false) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Unit/ConstraintFactoryTest.php
+++ b/tests/Unit/ConstraintFactoryTest.php
@@ -29,6 +29,18 @@ class ConstraintFactoryTest extends TestCase
      * @covers ::fromRuleDefinitions
      * @throws Exception
      */
+    public function testFromRuleDefinitionsConstraintListOnly(): void
+    {
+        $factory = new ConstraintFactory();
+        $constraintA = new Assert\NotBlank();
+        $constraintB = new Assert\NotNull();
+        static::assertSame([$constraintA, $constraintB], $factory->fromRuleDefinitions([$constraintA, $constraintB]));
+    }
+
+    /**
+     * @covers ::fromRuleDefinitions
+     * @throws Exception
+     */
     public function testFromRuleDefinitionsWithRule(): void
     {
         $factory = new ConstraintFactory();

--- a/tests/Unit/ConstraintFactoryTest.php
+++ b/tests/Unit/ConstraintFactoryTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @coversDefaultClass \DigitalRevolution\SymfonyValidationShorthand\ConstraintFactory
  * @covers ::__construct
+ * @covers ::isConstraintList
  */
 class ConstraintFactoryTest extends TestCase
 {


### PR DESCRIPTION
Modify the behaviour of the ConstraintFactory to ignore both `Constraint` and `Constraint[]` rule definition. If these types are given as argument, ignore the conversion and return the argument as is.