### PR TITLE
Fix Symfony constraint options deprecations

### DIFF
--- a/src/Constraint/ConstraintCollectionBuilder.php
+++ b/src/Constraint/ConstraintCollectionBuilder.php
@@ -78,7 +78,7 @@ class ConstraintCollectionBuilder
         }
 
         if ($required) {
-            return [new Assert\Count(['min' => 1]), new Assert\All($constraints)];
+            return [new Assert\Count(min: 1), new Assert\All($constraints)];
         }
 
         return new Assert\All($constraints);
@@ -105,7 +105,7 @@ class ConstraintCollectionBuilder
             $constraintMap[$key] = $this->getNodeConstraint($node, $optional);
         }
 
-        return new Assert\Collection(['fields' => $constraintMap, 'allowExtraFields' => $this->allowExtraFields]);
+        return new Assert\Collection($constraintMap, allowExtraFields: $this->allowExtraFields);
     }
 
     /**

--- a/src/Constraint/ConstraintResolver.php
+++ b/src/Constraint/ConstraintResolver.php
@@ -25,7 +25,7 @@ class ConstraintResolver
             return $constraints;
         }
 
-        $nullable    = false;
+        $nullable = false;
         $constraints = [];
         foreach ($ruleList->getRules() as $rule) {
             if ($rule instanceof Constraint) {
@@ -71,11 +71,11 @@ class ConstraintResolver
             case Rule::RULE_ARRAY:
                 return new Assert\Type('array');
             case Rule::RULE_ALPHA:
-                return new Assert\Regex(['pattern' => '/^[a-zA-Z]*$/']);
+                return new Assert\Regex('/^[a-zA-Z]*$/');
             case Rule::RULE_ALPHA_DASH:
-                return new Assert\Regex(['pattern' => '/^[\w-]*$/']);
+                return new Assert\Regex('/^[\w-]*$/');
             case Rule::RULE_ALPHA_NUM:
-                return new Assert\Regex(['pattern' => '/^[a-zA-Z0-9]*$/']);
+                return new Assert\Regex('/^[a-zA-Z0-9]*$/');
             case Rule::RULE_IN:
                 return new Type\InConstraint(['values' => $rule->getParameters()]);
             case Rule::RULE_DATE:
@@ -83,15 +83,15 @@ class ConstraintResolver
             case Rule::RULE_DATETIME:
                 return new Assert\DateTime();
             case Rule::RULE_DATE_FORMAT:
-                return new Assert\DateTime(['format' => $rule->getParameter(0)]);
+                return new Assert\DateTime($rule->getParameter(0));
             case Rule::RULE_EMAIL:
                 return new Assert\Email();
             case Rule::RULE_URL:
                 return new Assert\Url();
             case Rule::RULE_REGEX:
-                return new Assert\Regex(['pattern' => $rule->getParameter(0)]);
+                return new Assert\Regex($rule->getParameter(0));
             case Rule::RULE_FILLED:
-                return new Assert\NotBlank(['allowNull' => $ruleList->hasRule(Rule::RULE_NULLABLE)]);
+                return new Assert\NotBlank(allowNull: $ruleList->hasRule(Rule::RULE_NULLABLE));
             case Rule::RULE_MIN:
                 return $this->resolveMinConstraint($rule, $ruleList);
             case Rule::RULE_MAX:
@@ -118,7 +118,7 @@ class ConstraintResolver
             return new Assert\GreaterThanOrEqual($rule->getIntParam(0));
         }
 
-        return new Assert\Length(['min' => $rule->getIntParam(0)]);
+        return new Assert\Length(min: $rule->getIntParam(0));
     }
 
     /**
@@ -134,7 +134,7 @@ class ConstraintResolver
             return new Assert\LessThanOrEqual($rule->getIntParam(0));
         }
 
-        return new Assert\Length(['max' => $rule->getIntParam(0)]);
+        return new Assert\Length(max: $rule->getIntParam(0));
     }
 
     /**
@@ -143,13 +143,13 @@ class ConstraintResolver
     private function resolveBetweenConstraint(Rule $rule, RuleList $ruleList): Constraint
     {
         if ($ruleList->hasRule([Rule::RULE_DATE, Rule::RULE_DATETIME, Rule::RULE_DATE_FORMAT])) {
-            return new Assert\Range(['min' => $rule->getParameter(0), 'max' => $rule->getParameter(1)]);
+            return new Assert\Range(min: $rule->getParameter(0), max: $rule->getParameter(1));
         }
 
         if ($ruleList->hasRule([Rule::RULE_INTEGER, Rule::RULE_FLOAT])) {
-            return new Assert\Range(['min' => $rule->getIntParam(0), 'max' => $rule->getIntParam(1)]);
+            return new Assert\Range(min: $rule->getIntParam(0), max: $rule->getIntParam(1));
         }
 
-        return new Assert\Length(['min' => $rule->getIntParam(0), 'max' => $rule->getIntParam(1)]);
+        return new Assert\Length(min: $rule->getIntParam(0), max: $rule->getIntParam(1));
     }
 }

--- a/tests/Unit/Constraint/ConstraintCollectionBuilderTest.php
+++ b/tests/Unit/Constraint/ConstraintCollectionBuilderTest.php
@@ -26,8 +26,7 @@ use Symfony\Component\Validator\Constraints\Required;
  */
 class ConstraintCollectionBuilderTest extends TestCase
 {
-    /** @var ConstraintCollectionBuilder */
-    private $builder;
+    private ConstraintCollectionBuilder $builder;
 
     protected function setUp(): void
     {
@@ -41,7 +40,7 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildSingleNonNestedConstraint(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('a', new ConstraintMapItem([$constraint], true));
 
@@ -57,12 +56,12 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildSingleCollectionAllowExtraFieldsConstraint(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('a', new ConstraintMapItem([$constraint], true));
 
         $result = $this->builder->setAllowExtraFields(true)->build($constraintMap);
-        $expect = new Collection(['fields' => ['a' => new NotNull()], 'allowExtraFields' => true]);
+        $expect = new Collection(['a' => new NotNull()], allowExtraFields: true);
         static::assertEquals($expect, $result);
     }
 
@@ -72,7 +71,7 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildSingleNestedConstraint(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('a.b', new ConstraintMapItem([$constraint], true));
 
@@ -87,8 +86,8 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildMultipleNestedConstraints(): void
     {
-        $constraintA   = new NotNull();
-        $constraintB   = new Blank();
+        $constraintA = new NotNull();
+        $constraintB = new Blank();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('a.a', new ConstraintMapItem([$constraintA], true));
         $constraintMap->set('a.b', new ConstraintMapItem([$constraintB], true));
@@ -104,7 +103,7 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildOptionalConstraints(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('a?.b', new ConstraintMapItem([$constraint], true));
 
@@ -121,7 +120,7 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildOptionalConstraintShouldNotOverwriteRequired(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('a.b?', new ConstraintMapItem([$constraint], true));
 
@@ -136,13 +135,13 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildWithNonEmptyAllConstraint(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('*', new ConstraintMapItem([$constraint], true));
 
         $result = $this->builder->build($constraintMap);
         $expect = [
-            new Count(['min' => 1]),
+            new Count(min: 1),
             new All([new NotNull()])
         ];
         static::assertEquals($expect, $result);
@@ -154,7 +153,7 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildWithEmptyAllConstraint(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('*', new ConstraintMapItem([$constraint], false));
 
@@ -169,13 +168,13 @@ class ConstraintCollectionBuilderTest extends TestCase
      */
     public function testBuildWithAllAndCollectionConstraint(): void
     {
-        $constraint    = new NotNull();
+        $constraint = new NotNull();
         $constraintMap = new ConstraintMap();
         $constraintMap->set('*.name', new ConstraintMapItem([$constraint], true));
 
         $result = $this->builder->build($constraintMap);
         $expect =
-            new All([new Collection(['fields' => ['name' => $constraint]])]);
+            new All([new Collection(['name' => $constraint])]);
 
         static::assertEquals($expect, $result);
     }

--- a/tests/Unit/Constraint/ConstraintResolverTest.php
+++ b/tests/Unit/Constraint/ConstraintResolverTest.php
@@ -72,22 +72,22 @@ class ConstraintResolverTest extends TestCase
     public function dataProvider(): Generator
     {
         yield 'constraint' => [[new Assert\NotBlank()], [new Assert\NotBlank()]];
-        yield 'rule + constraint' => [[new Assert\NotBlank(), new Assert\NotNull()],[new Rule('required'), new Assert\NotBlank()]];
+        yield 'rule + constraint' => [[new Assert\NotBlank(), new Assert\NotNull()], [new Rule('required'), new Assert\NotBlank()]];
         yield 'boolean' => [[new BooleanValue(), new Assert\NotNull()], [new Rule('boolean')]];
         yield 'integer' => [[new IntegerNumber(), new Assert\NotNull()], [new Rule('integer')]];
         yield 'float' => [[new FloatNumber(), new Assert\NotNull()], [new Rule('float')]];
         yield 'array' => [[new Assert\Type('array'), new Assert\NotNull()], [new Rule('array')]];
         yield 'string' => [[new Assert\Type('string'), new Assert\NotNull()], [new Rule('string')]];
-        yield 'alpha' => [[new Assert\Regex(['pattern' => '/^[a-zA-Z]*$/']), new Assert\NotNull()], [new Rule('alpha')]];
-        yield 'alpha_dash' => [[new Assert\Regex(['pattern' => '/^[\w-]*$/']), new Assert\NotNull()], [new Rule('alpha_dash')]];
-        yield 'alpha_num' => [[new Assert\Regex(['pattern' => '/^[a-zA-Z0-9]*$/']), new Assert\NotNull()], [new Rule('alpha_num')]];
+        yield 'alpha' => [[new Assert\Regex('/^[a-zA-Z]*$/'), new Assert\NotNull()], [new Rule('alpha')]];
+        yield 'alpha_dash' => [[new Assert\Regex('/^[\w-]*$/'), new Assert\NotNull()], [new Rule('alpha_dash')]];
+        yield 'alpha_num' => [[new Assert\Regex('/^[a-zA-Z0-9]*$/'), new Assert\NotNull()], [new Rule('alpha_num')]];
         yield 'in' => [[new InConstraint(['values' => ['a', 'b']]), new Assert\NotNull()], [new Rule('in', ['a', 'b'])]];
         yield 'email' => [[new Assert\Email(), new Assert\NotNull()], [new Rule('email')]];
         yield 'url' => [[new Assert\Url(), new Assert\NotNull()], [new Rule('url')]];
         yield 'filled' => [[new Assert\NotBlank(), new Assert\NotNull()], [new Rule('filled')]];
-        yield 'filled nullable' => [[new Assert\NotBlank(['allowNull' => true])], [new Rule('filled'), new Rule('nullable')]];
+        yield 'filled nullable' => [[new Assert\NotBlank(allowNull: true)], [new Rule('filled'), new Rule('nullable')]];
         yield 'regex' => [
-            [new Assert\Regex(['pattern' => '/^unittest$/']), new Assert\NotNull()],
+            [new Assert\Regex('/^unittest$/'), new Assert\NotNull()],
             [new Rule('regex', ['/^unittest$/'])]
         ];
         yield 'required' => [[new Assert\NotNull()], [new Rule('required')]];
@@ -96,7 +96,7 @@ class ConstraintResolverTest extends TestCase
         // date, datetime, date_format
         yield 'date' => [[new Assert\Date(), new Assert\NotNull()], [new Rule('date')]];
         yield 'datetime' => [[new Assert\DateTime(), new Assert\NotNull()], [new Rule('datetime')]];
-        yield 'date_format' => [[new Assert\DateTime(['format' => 'd/m/Y']), new Assert\NotNull()], [new Rule('date_format', ['d/m/Y'])]];
+        yield 'date_format' => [[new Assert\DateTime('d/m/Y'), new Assert\NotNull()], [new Rule('date_format', ['d/m/Y'])]];
         yield 'date min' => [
             [new Assert\Date(), new Assert\GreaterThanOrEqual('now'), new Assert\NotNull()],
             [new Rule('date'), new Rule('min', ['now'])]
@@ -106,15 +106,15 @@ class ConstraintResolverTest extends TestCase
             [new Rule('date'), new Rule('max', ['now'])]
         ];
         yield 'date between' => [
-            [new Assert\Date(), new Assert\Range(['min' => '-10 days', 'max' => '+10 days']), new Assert\NotNull()],
+            [new Assert\Date(), new Assert\Range(min: '-10 days', max: '+10 days'), new Assert\NotNull()],
             [new Rule('date'), new Rule('between', ['-10 days', '+10 days'])]
         ];
 
         // min/max string or array lengths
-        yield 'min length' => [[new Assert\Length(['min' => 10]), new Assert\NotNull()], [new Rule('min', ['10'])]];
-        yield 'max length' => [[new Assert\Length(['max' => 10]), new Assert\NotNull()], [new Rule('max', ['10'])]];
+        yield 'min length' => [[new Assert\Length(min: 10), new Assert\NotNull()], [new Rule('min', ['10'])]];
+        yield 'max length' => [[new Assert\Length(max: 10), new Assert\NotNull()], [new Rule('max', ['10'])]];
         yield 'min/max length' => [
-            [new Assert\Length(['min' => 10, 'max' => 20]), new Assert\NotNull()],
+            [new Assert\Length(min: 10, max: 20), new Assert\NotNull()],
             [new Rule('between', ['10', '20'])]
         ];
 
@@ -128,7 +128,7 @@ class ConstraintResolverTest extends TestCase
             [new Rule('integer'), new Rule('max', ['20'])]
         ];
         yield 'min/max integer' => [
-            [new IntegerNumber(), new Assert\Range(['min' => 10, 'max' => 20]), new Assert\NotNull()],
+            [new IntegerNumber(), new Assert\Range(min: 10, max: 20), new Assert\NotNull()],
             [new Rule('integer'), new Rule('between', ['10', '20'])]
         ];
     }

--- a/tests/Unit/ConstraintFactoryTest.php
+++ b/tests/Unit/ConstraintFactoryTest.php
@@ -45,7 +45,7 @@ class ConstraintFactoryTest extends TestCase
     public function testFromRuleDefinitionsWithRule(): void
     {
         $factory = new ConstraintFactory();
-        $expect  = new Assert\Collection(['email' => new Assert\Required([new Assert\Email(), new Assert\NotNull()])]);
+        $expect = new Assert\Collection(['email' => new Assert\Required([new Assert\Email(), new Assert\NotNull()])]);
         static::assertEquals($expect, $factory->fromRuleDefinitions(['email' => 'required|email'], false));
     }
 
@@ -56,8 +56,9 @@ class ConstraintFactoryTest extends TestCase
     public function testFromRuleDefinitionsWithRuleAllowExtraFields(): void
     {
         $factory = new ConstraintFactory();
-        $expect  = new Assert\Collection(
-            ['fields' => ['email' => new Assert\Required([new Assert\Email(), new Assert\NotNull()])], 'allowExtraFields' => true]
+        $expect = new Assert\Collection(
+            ['email' => new Assert\Required([new Assert\Email(), new Assert\NotNull()])],
+            allowExtraFields: true
         );
         static::assertEquals($expect, $factory->fromRuleDefinitions(['email' => 'required|email'], true));
     }


### PR DESCRIPTION
Use separate constraint parameters instead of the options array to fix Symfony 7.3 deprecation triggers